### PR TITLE
hls: Add `warp` query param

### DIFF
--- a/src/hls.rs
+++ b/src/hls.rs
@@ -182,6 +182,7 @@ pub fn fetch_proxy_playlist(servers: &[String], channel: &str, quality: &str) ->
                     ("allow_source", "true"),
                     ("allow_audio_only", "true"),
                     ("fast_bread", "true"),
+                    ("warp", "true"),
                 ],
             )
         })


### PR DESCRIPTION
Uses QUIC and is lower latency due to that, doesn't seem to have any downside, adless when proxied
https://www.ietf.org/archive/id/draft-lcurley-warp-00.html