### PR TITLE
Add `platform` query param to usher

### DIFF
--- a/src/hls.rs
+++ b/src/hls.rs
@@ -209,6 +209,7 @@ impl MediaPlaylist {
                 ),
                 ("os_name", "Windows"),
                 ("os_version", "NT 10.0"),
+                ("platform", "web"),
             ],
         )?;
 
@@ -237,6 +238,7 @@ impl MediaPlaylist {
                         ("fast_bread", "true"),
                         ("warp", "true"),
                         ("supported_codecs", &codecs),
+                        ("platform", "web"),
                     ],
                 )
             })


### PR DESCRIPTION
Currently, the `platform` query param must be set to `web` to request `av1` (in `supported_codecs`) HLS playlists from usher.
~~I've opened a PR in luminous as well to add relay the query param in proxies.~~ merged