### PR TITLE
Adds support for NixOS with flake and hm-module

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,74 @@ Alternatively, you can build it yourself by installing the [Rust toolchain](http
 cargo install --locked --git https://github.com/2bc4/twitch-hls-client.git
 ```
 
+#### NixOS
+
+<details closed>
+<summary>Flake Package</summary>
+
+```nix
+# flake.nix
+
+{
+  inputs.twitch-hls-client.url = "github:2bc4/twitch-hls-client";
+  # ...
+
+  outputs = {nixpkgs, ...} @ inputs: {
+    nixosConfigurations.HOSTNAME = nixpkgs.lib.nixosSystem {
+      specialArgs = { inherit inputs; }; # this is the important part
+      modules = [
+        ./configuration.nix
+      ];
+    };
+  } 
+}
+```
+
+```nix
+# configuration.nix
+
+{inputs, pkgs, ...}: {
+  programs.twitch-hls-client = {
+    enable = true;
+    package = inputs.twitch-hls-client.packages.${pkgs.system}.default;
+  };
+}
+```
+
+</details>
+
+<details closed>
+<summary>Flake Home-Manager</summary>
+
+```nix
+# twitch-hls-client.nix
+{
+  programs.twitch-hls-client = {
+    enable = true;
+    # ...
+
+    # This is a example to use -c config file every time
+    systemd.user.services.twitch-hls-client = {
+      Unit = {
+        Description = "Twitch HLS Client Service";
+      };
+
+      Service = {
+        Type = "simple";
+        ExecStart = "twitch-hls-client -c ${config.xdg.configHome}/twitch-hls-client/config";
+        Restart = "always";
+      };
+
+      Install = {
+        WantedBy = ["default.target"];
+      };
+    };
+  };
+}
+```
+
+</details>
+
 #### Optional build time features
 - `colors` - Enable terminal colors (enabled by default)
 - `debug-logging` - Enable debug logging support

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1709965418,
+        "narHash": "sha256-xsKCrFDU6rU3oIqMP3IbuAGiJvsVeBTRqZvwN1p1q4c=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "24002092be13b2efe87700229d143b0d1eaa5d12",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1709703039,
+        "narHash": "sha256-6hqgQ8OK6gsMu1VtcGKBxKQInRLHtzulDo9Z5jxHEFY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9df3e30ce24fd28c7b3e2de0d986769db5d6225d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1709904211,
+        "narHash": "sha256-Vv29QP5eIn9ZEapQzXHqwhjm46sddetiZScTWY0/dlA=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "2397e7a887252aa995d3790164b34b6c76ed94b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,44 @@
+{
+  description = "A minimal command line client for watching/recording Twitch streams";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    systems.url = "github:nix-systems/default-linux";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    fenix,
+    systems,
+    ...
+  } @ inputs: let
+    inherit (nixpkgs) lib;
+    eachSystem = lib.genAttrs (import systems);
+    pkgsFor = eachSystem (system:
+      import nixpkgs {
+        localSystem.system = system;
+        overlays = [self.overlays.default];
+      });
+  in {
+    overlays = {default = import ./nix/overlays.nix {inherit fenix;};};
+
+    packages = eachSystem (system: {
+      default = self.packages.${system}.twitch-hls-client;
+      inherit (pkgsFor.${system}) twitch-hls-client;
+    });
+
+    homeManagerModules = {
+      default = self.homeManagerModules.twitch-hls-client;
+      twitch-hls-client = import ./nix/hm-module.nix self;
+    };
+
+    checks = eachSystem (system: self.packages.${system});
+
+    formatter = eachSystem (system: pkgsFor.${system}.alejandra);
+  };
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,51 @@
+{
+  system,
+  pkgs,
+  lib,
+  makeWrapper,
+  rustPlatform,
+  pkg-config,
+  rustfmt,
+  lockFile,
+  fenix,
+}: let
+  cargoToml = builtins.fromTOML (builtins.readFile ../Cargo.toml);
+  toolchain = fenix.packages.${system}.minimal.toolchain;
+in
+  (pkgs.makeRustPlatform {
+    cargo = toolchain;
+    rustc = toolchain;
+  })
+  .buildRustPackage rec {
+    pname = cargoToml.package.name;
+    version = cargoToml.package.version;
+
+    src = ../.;
+
+    cargoLock = {
+      lockFile = ../Cargo.lock;
+    };
+
+    nativeBuildInputs = [
+      pkg-config
+      makeWrapper
+      rustfmt
+    ];
+
+    doCheck = true;
+    CARGO_BUILD_INCREMENTAL = "false";
+    RUST_BACKTRACE = "full";
+    copyLibs = true;
+
+    postInstall = ''
+      wrapProgram $out/bin/twitch-hls-client
+    '';
+
+    meta = {
+      homepage = "https://github.com/2bc4/twitch-hls-client";
+      description = "A minimal command line client for watching/recording Twitch streams";
+      license = lib.licenses.gpl3;
+      platforms = lib.platforms.linux;
+      mainProgram = "twitch-hls-client";
+    };
+  }

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -1,0 +1,149 @@
+self: {
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (lib.types) bool int package str;
+  inherit (lib.modules) mkIf;
+  inherit (lib.options) mkOption mkEnableOption;
+
+  boolToString = x:
+    if x
+    then "true"
+    else "false";
+  cfg = config.programs.twitch-hls-client;
+  filterOptions = options:
+    builtins.filter (opt: builtins.elemAt opt 1 != "") options;
+in {
+  options.programs.twitch-hls-client = {
+    enable =
+      mkEnableOption ""
+      // {
+        description = ''
+          twitch-hls-client is a minimal command line client for watching/recording Twitch streams
+
+          Features
+          Playback of low latency and normal latency streams
+          Ad blocking with playlist proxies or with a turbo/subscriber token
+          Generally lower latency than the Twitch web player
+          Tiny (at most uses 3-4MB of memory)
+        '';
+      };
+
+    package = mkOption {
+      description = "The twitch-hls-client package";
+      type = package;
+      default = self.packages.${pkgs.stdenv.hostPlatform.system}.twitch-hls-client;
+    };
+    player = mkOption {
+      description = "Path to player";
+      type = package;
+      default = pkgs.mpv;
+    };
+    player-args = mkOption {
+      description = "Arguments to pass to the player [default: -]";
+      type = str;
+    };
+    record = mkOption {
+      description = "Record to <PATH>";
+      type = str;
+    };
+    servers = mkOption {
+      description = "Ad blocking playlist proxy server to fetch the master playlist from. If not specified will fetch the master playlist directly from Twitch. Can be multiple comma separated servers, will try each in order until successful. If URL includes the keyword '[channel]' it will be replaced with the channel argument at runtime. Note: This does not support standard HTTP proxies (ie. proxies using the CONNECT request)";
+      type = str;
+    };
+    debug = mkOption {
+      description = "Enable debug logging";
+      type = bool;
+      default = false;
+    };
+    quiet = mkOption {
+      description = "Silence player output";
+      type = bool;
+      default = true;
+    };
+    passthrough = mkOption {
+      description = "Passthrough playlist URL to player and do nothing else";
+      type = bool;
+    };
+    print-streams = mkOption {
+      description = "Print available stream qualities and exit";
+      type = bool;
+    };
+    overwrite = mkOption {
+      description = "Allow overwriting file when recording";
+      type = bool;
+    };
+    no-low-latency = mkOption {
+      description = "Disable low latency streaming";
+      type = bool;
+    };
+    no-kill = mkOption {
+      description = "Don't kill the player on exit";
+      type = bool;
+    };
+    force-https = mkOption {
+      description = "Abort request if protocol is not HTTPS";
+      type = bool;
+      default = true;
+    };
+    force-ipv4 = mkOption {
+      description = "Only use IPv4 addresses when resolving host names";
+      type = bool;
+      default = false;
+    };
+    client-id = mkOption {
+      description = "Value to be used in the Client-Id header. If not specified will use the default client ID";
+      type = str;
+    };
+    auth-token = mkOption {
+      description = "Value to be used in the Authorization header. If --client-id is not specified will retrieve client ID from Twitch";
+      type = str;
+    };
+    never-proxy = mkOption {
+      description = "Prevent specified channels from using a playlist proxy. Can be multiple comma separated channels";
+      type = str;
+    };
+    codecs = mkOption {
+      description = "Comma separated list of supported codecs [default: av1,h265,h264]";
+      type = str;
+    };
+    user-agent = mkOption {
+      description = "User agent used in HTTP requests [default: a recent version of Firefox on Windows 10]";
+      type = str;
+    };
+    http-retries = mkOption {
+      description = "Retry HTTP requests <COUNT> times before giving up [default: 3]";
+      type = int;
+    };
+    http-timeout = mkOption {
+      description = "HTTP request timeout in seconds [default: 10]";
+      type = int;
+    };
+    quality = mkOption {
+      description = "Stream quality/variant playlist to stream (best, 1080p, 720p, 360p, 160p, audio_only, etc.)";
+      type = str;
+      default = "720p";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [cfg.package];
+
+    xdg.configFile."twitch-hls-client/config".text = let
+      formatOption = name: value: "${name}=${value}";
+      formatConfig = options:
+        builtins.concatStringsSep "\n" (map (opt: formatOption (builtins.head opt) (builtins.elemAt opt 1)) options);
+    in ''
+      ${formatConfig (filterOptions [
+        ["player" (lib.getExe cfg.player)]
+        ["debug" (boolToString cfg.debug)]
+        ["quiet" (boolToString cfg.quiet)]
+        ["force-https" (boolToString cfg."force-https")]
+        ["force-ipv4" (boolToString cfg."force-ipv4")]
+        ["quality" cfg.quality]
+      ])}
+    '';
+  };
+}

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -1,0 +1,6 @@
+{fenix}: final: prev: {
+  twitch-hls-client = prev.callPackage ./default.nix {
+    lockFile = ./Cargo.lock;
+    fenix = fenix;
+  };
+}


### PR DESCRIPTION
### Description:

This pull request adds support for NixOS via a flake and a Home Manager module, making it easier to install and configure twitch-hls-client on Nix-managed systems. Updated README.md with instructions for installation and configuration.

### Major Changes:

- Introduction of a Nix flake for support on NixOS.
- Created a Home Manager module for custom configuration.
- Updated README.md with installation guide for NixOS.


**Objective:**
Provide a simple and effective integration for NixOS users, improving the accessibility and user experience of twitch-hls-client.

### Testing Instructions:

- Install Nix / Home Manager.
- Follow the installation and configuration instructions in the updated README.md.
- Rebuild the environment and verify the installation.
- Any feedback to improve the integration is appreciated.


_(tested and used in my configuration)_

![image](https://github.com/2bc4/twitch-hls-client/assets/10554636/31a8d809-3e1d-479e-ab34-a669e054281b)

