### PR TITLE
fix(config): Missing `ok` method on `env::var`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -480,7 +480,7 @@ impl Parser {
     fn default_config_path() -> Option<String> {
         Some(format!(
             "{}/{}",
-            env::var("APPDATA")?,
+            env::var("APPDATA").ok()?,
             constants::DEFAULT_CONFIG_PATH,
         ))
     }
@@ -489,7 +489,7 @@ impl Parser {
     fn default_config_path() -> Option<String> {
         Some(format!(
             "{}/Library/Application Support/{}",
-            env::var("HOME")?,
+            env::var("HOME").ok()?,
             constants::DEFAULT_CONFIG_PATH,
         ))
     }


### PR DESCRIPTION
Regression from 2223d5b82c8e49363cb5f3d2cc3db2f78bd1b006, doesn't currently build.
```
   Compiling twitch-hls-client v1.6.2 (~\Documents\GitHub\twitch-hls-client)
error[E0277]: the `?` operator can only be used on `Option`s, not `Result`s, in a method that returns `Option`
   --> src\config.rs:483:32
    |
480 |     fn default_config_path() -> Option<String> {
    |     ------------------------------------------ this function returns an `Option`
...
483 |             env::var("APPDATA")?,
    |                                ^ use `.ok()?` if you want to discard the `Result<Infallible, VarError>` error information

For more information about this error, try `rustc --explain E0277`.
error: could not compile `twitch-hls-client` (bin "twitch-hls-client") due to 1 previous error
```